### PR TITLE
Enable translation of "href" attribute.

### DIFF
--- a/js/jquery-lang.js
+++ b/js/jquery-lang.js
@@ -97,7 +97,8 @@ var Lang = (function () {
 	Lang.prototype.attrList = [
 		'title',
 		'alt',
-		'placeholder'
+		'placeholder',
+		'href'
 	];
 
 	/**


### PR DESCRIPTION
If you need to make language dependent links to external sites. For example "http://www.apple.com/cz/"