### PR TITLE
Translating long text with a custom defined token

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,22 @@ alert() you can use the translate() method:
 
     alert(window.lang.translate('Some text to translate'));
 
+# Translating long text with a custom defined token
+
+If you do not want to create translation files with long tokens, you can specify custom tokens for elements which contain long text.
+
+To define a custom token, add a data-lang-token attribute to the element.
+```html
+<div lang="en" data-lang-token="lorem">Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in ...</div>
+```
+
+To translate the long text
+```json
+"lorem" : "ตรงกันข้ามกับความเชื่อที่นิยมกัน Lorem Ipsum ไม่ได้เป็นเพียงแค่ชุดตัวอักษรที่สุ่มขึ้นมามั่วๆ แต่หากมีที่มาจากวรรณกรรมละตินคลาสสิกชิ้นหนึ่งในยุค  ..."
+```
+
+**Limitation:** Elements with data-lang-token attribute, have to contain only one text node, otherwise the plugin uses text content as a token.
+
 # Dynamic content
 
 If you load content dynamically and add it to the DOM using jQuery the plugin will AUTOMATICALLY translate

--- a/index.html
+++ b/index.html
@@ -188,6 +188,14 @@
 						<div id="dyn-target" lang="en"></div>
 					</td>
 				</tr>
+				
+				<tr>
+					<td>
+						Long text translation with a custom defined token(data-lang-token attribute):<br>
+						
+						<div lang="en" data-lang-token="lorem">Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in ...</div>
+					</td>
+				</tr>
 			</table>
 		</form>
 	</div>

--- a/js/jquery-lang.js
+++ b/js/jquery-lang.js
@@ -291,6 +291,12 @@ var Lang = (function () {
 			nodeObjArray.push(nodeObj);
 		});
 		
+		// If element has only one text node and data-lang-token is defined
+		// set langContentKey property to use as a token
+		if(nodes.length == 1){
+			nodeObjArray[0].langToken = elem.data('langToken');
+		}
+		
 		return nodeObjArray;
 	};
 
@@ -312,7 +318,8 @@ var Lang = (function () {
 			textNode = nodes[index];
 			
 			if (langNotDefault) {
-				defaultText = $.trim(textNode.langDefaultText);
+				// If langToken is set, use it as a token
+				defaultText = textNode.langToken || $.trim(textNode.langDefaultText);
 				
 				if (defaultText) {
 					// Translate the langDefaultText

--- a/js/langpack/th.json
+++ b/js/langpack/th.json
@@ -68,7 +68,8 @@
 		"Full Description":"รายละเอียดเพิ่มเติมสำหรับผู้สนใจประกาศ",
 		"Property Photos":"รูปภาพสถานที่",
 	  	"http://www.ioling.org/images/flags/uk.gif": "http://upload.wikimedia.org/wikipedia/commons/thumb/a/a9/Flag_of_Thailand.svg/1280px-Flag_of_Thailand.svg.png",
-		"http://www.google.com/": "http://www.yahoo.com/"
+		"http://www.google.com/": "http://www.yahoo.com/",
+		"lorem" : "ตรงกันข้ามกับความเชื่อที่นิยมกัน Lorem Ipsum ไม่ได้เป็นเพียงแค่ชุดตัวอักษรที่สุ่มขึ้นมามั่วๆ แต่หากมีที่มาจากวรรณกรรมละตินคลาสสิกชิ้นหนึ่งในยุค  ..."
 	},
 	"regex": [
 		["Budget", "งบประมาณ"],


### PR DESCRIPTION
Add the capability to create translation files with long tokens, you can specify custom tokens for elements which contain long text.  ( issue #50 ) 

To define a custom token, add a data-lang-token attribute to the element.
```html
<div lang="en" data-lang-token="lorem">Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in ...</div>
```

To translate the long text
```json
"lorem" : "ตรงกันข้ามกับความเชื่อที่นิยมกัน Lorem Ipsum ไม่ได้เป็นเพียงแค่ชุดตัวอักษรที่สุ่มขึ้นมามั่วๆ แต่หากมีที่มาจากวรรณกรรมละตินคลาสสิกชิ้นหนึ่งในยุค  ..."
```