### PR TITLE
feat: Factory supports windowed Node environments

### DIFF
--- a/js/jquery-lang.js
+++ b/js/jquery-lang.js
@@ -32,7 +32,7 @@
 	if (typeof define === "function" && define.amd) {
 		define(["jquery", "Cookies"], factory);
 	} else if (typeof exports === "object") {
-		module.exports = factory();
+		module.exports = factory(window && window.$, window && window.Cookies);
 	} else {
 		var _OldLang = window.Lang;
 		var api = window.Lang = factory(jQuery, typeof Cookies !== "undefined" ? Cookies : undefined);


### PR DESCRIPTION
On windowed Node environments such as NW.js and Electron the current CommonJS export factory invocation doesn't pass on the required `JQuery` and `Cookies` global references. This PR allows a NW.js or Electron app to `import`/`require` the module instead of including it on the app html if the required global objects are available.